### PR TITLE
Fix sourceCode.getLeadingComments throwing on some ESLint versions

### DIFF
--- a/build-packages/eslint-plugin-scandipwa-guidelines/lib/rules/use-magic-construct.js
+++ b/build-packages/eslint-plugin-scandipwa-guidelines/lib/rules/use-magic-construct.js
@@ -1,3 +1,5 @@
+const getLeadingCommentsForNode = require('../util/get-leading-comments');
+
 /**
  * @fileoverview All components should be extensible.
  * @author Jegors Batovs
@@ -9,7 +11,7 @@ const hasNamespace = (node, context) => {
 		? node.parent
 		: node;
 
-    const leadingComments = context.getSourceCode().getCommentsBefore(nodeToProcess);
+    const leadingComments = getLeadingCommentsForNode(nodeToProcess, context.getSourceCode());
 
     const namespaceComment = leadingComments.find(
 		({ value }) => value.match(/@namespace/)

--- a/build-packages/eslint-plugin-scandipwa-guidelines/lib/rules/use-namespace.js
+++ b/build-packages/eslint-plugin-scandipwa-guidelines/lib/rules/use-namespace.js
@@ -6,6 +6,7 @@
 const path = require('path');
 const { getPackageJson } = require('@scandipwa/scandipwa-dev-utils/package-json');
 const fixNamespaceLack = require('../util/fix-namespace-lack.js');
+const getLeadingCommentsForNode = require('../util/get-leading-comments');
 
 const types = {
     ExportedClass: [
@@ -82,9 +83,9 @@ const getNamespaceCommentForNode = (node, sourceCode) => {
     const getNamespaceFromComments = (comments = []) => comments.find(
         comment => comment.value.includes('@namespace')
     );
-    
+
     return getNamespaceFromComments(
-        sourceCode.getCommentsBefore(getProperParentNode(node))
+        getLeadingCommentsForNode(getProperParentNode(node), sourceCode)
     );
 };
 

--- a/build-packages/eslint-plugin-scandipwa-guidelines/lib/util/fix-namespace-lack.js
+++ b/build-packages/eslint-plugin-scandipwa-guidelines/lib/util/fix-namespace-lack.js
@@ -1,3 +1,5 @@
+const getLeadingCommentsForNode = require('./get-leading-comments');
+
 /**
  * Insert namespace decorator comment before the appropriate node
  * @param {Fixer} fixer
@@ -6,19 +8,17 @@
  * @param {string} namespace
  */
 module.exports = (fixer, node, context, namespace) => {
-	const sourceCode = context.getSourceCode();
-	const leadingComments = sourceCode.getLeadingComments(node);
+    const sourceCode = context.getSourceCode();
+    const leadingComments = getLeadingCommentsForNode(node, sourceCode);
 
     if (leadingComments.find(comment => comment.value.includes('@namespace'))) {
         return null;
     }
 
     const blockComment = leadingComments.reverse().find(
-         comment => comment.type === 'Block' && !['eslint-disable-next-line', '@license'].some(cond => comment.value.includes(cond))
+        comment => comment.type === 'Block' && !['eslint-disable-next-line', '@license'].some(cond => comment.value.includes(cond))
     );
-    const lineComment = leadingComments.reverse().find(
-        ({ type }) => type === 'Line'
-    );
+
     const eslintComment = leadingComments.find(
         comment => comment.value.includes('eslint-disable-next-line')
     );
@@ -29,6 +29,7 @@ module.exports = (fixer, node, context, namespace) => {
             '/*' + blockComment.value.concat(`* @namespace ${namespace}`) + '\n */'
         );
     }
+
     if (eslintComment) {
         return fixer.insertTextBefore(eslintComment, `/** @namespace ${namespace} */\n`);
     }

--- a/build-packages/eslint-plugin-scandipwa-guidelines/lib/util/get-leading-comments.js
+++ b/build-packages/eslint-plugin-scandipwa-guidelines/lib/util/get-leading-comments.js
@@ -1,0 +1,24 @@
+module.exports = (node, sourceCode) => {
+    if (!sourceCode) {
+        throw new Error('Please provide an instance of SourceCode to resolve comments for node');
+    }
+
+    // ESLint ~4
+    if (typeof sourceCode.getCommentsBefore === 'function') {
+        return sourceCode.getCommentsBefore(node);
+    }
+
+    // ESLint ~3.9.1
+    if (typeof sourceCode.getComments === 'function') {
+        const { leading } = sourceCode.getComments(node);
+
+        return leading;
+    }
+
+    // ESLint circa 3
+    if (typeof sourceCode.getLeadingComments === 'function') {
+        return sourceCode.getLeadingComments(node);
+    }
+
+    throw new Error('Unable to retrieve comments for the node.');
+};


### PR DESCRIPTION
### Context

ESLint apparently likes changing the comment retrieval API every once in a while - I currently know 4 for 4 different versions of ESLint. Of course, these API changes are not backwards-compatible. Sad.

### Overview

This PR makes CSA support 3 of them (handled in the `get-leading-namespace` util function). The fourth one is so legacy that it should not cause any trouble.

### Requirements for future coding style

Further on, it should be ensured that this utility is used for comment retrieval in order to support multiple ESLint versions with our ESLint plugin. The code has been scanned for direct comments' retrieval and all of them have been removed.