### PR TITLE
Fix instability on some machines

### DIFF
--- a/build-packages/webpack-i18n-runtime/build-config/webpack-i18n-import-loader/index.js
+++ b/build-packages/webpack-i18n-runtime/build-config/webpack-i18n-import-loader/index.js
@@ -70,7 +70,7 @@ function generateLocaleMapContents(localePathMap, defaultLocale) {
 module.exports = function injectImports(source) {
     const {
         defaultLocale = 'en_US'
-    } = loaderUtils.getOptions(this);
+    } = loaderUtils.getOptions(this) || {};
 
     // Get the active locales from the current theme's package.json
     const locales = getEnabledLocales();


### PR DESCRIPTION
### Overview

It has been proven that this place may work differently - on the same project, on different machines, both installed by yarn, `loader-utils` options retrieval can return either `null` or `{}`. When `null` is returned, the application cannot be compiled.

This PR fixes this issue.