### PR TITLE
Fix broken inheritance

### DIFF
--- a/build-packages/scandipwa-extensibility/Extensible.js
+++ b/build-packages/scandipwa-extensibility/Extensible.js
@@ -20,10 +20,11 @@ export default (BaseClass = EmptyBase) => {
     }
 
     const { name } = BaseClass;
-    const {
+    // Get the cache identity for the base class, omit inherited prop
+    const { 
         // Generate unique cache identities as default value
-        [cacheIdentityKey]: cacheIdentity = Symbol(`Cache Identity ${name}`)
-    } = BaseClass;
+        value: cacheIdentity = Symbol(`Cache Identity ${name}`)
+    } = Object.getOwnPropertyDescriptor(BaseClass, cacheIdentityKey) || {};
 
     // If such class is not yet generated => generate the class
     if (!generated[cacheIdentity]) {

--- a/build-packages/scandipwa-extensibility/build-config/babel-plugin-middleware-decorator/index.js
+++ b/build-packages/scandipwa-extensibility/build-config/babel-plugin-middleware-decorator/index.js
@@ -73,7 +73,7 @@ const addSuperToConstructor = (path, types) => {
 
 /**
  * Attempt to read package.json located by p
- * @param {string} packageJsonPath 
+ * @param {string} packageJsonPath
  */
 const getPackageJson = (packagePath) => {
     const packageJsonPath = path.join(packagePath, 'package.json');
@@ -81,15 +81,15 @@ const getPackageJson = (packagePath) => {
     try {
         return require(packageJsonPath);
     } catch (err) {
-        return {}
+        return {};
     }
-}
+};
 
 /**
  * Memoization strategy is valid only for functions with 1 argument
  * This strategy works better with 1-argument functions
- * 
- * @param {function} cb 
+ *
+ * @param {function} cb
  */
 const memoizeBySingleArgument = (cb) => {
     const memoizedValues = {};
@@ -100,14 +100,17 @@ const memoizeBySingleArgument = (cb) => {
             const result = cb(arg);
             memoizedValues[arg] = result;
         }
-        
+
         return memoizedValues[arg];
     };
-}
+};
 
 const isScandipwaPackageFile = memoizeBySingleArgument((filePath) => {
     // Potentially, only the files inside of the src/ directory need to be transpiled
     const src = filePath.lastIndexOf('/src/');
+    if (src === -1) {
+        return false;
+    }
 
     const packagePath = filePath.slice(0, src);
     const packageJson = getPackageJson(packagePath);

--- a/build-packages/scandipwa-extensibility/build-config/babel-plugin-middleware-decorator/index.js
+++ b/build-packages/scandipwa-extensibility/build-config/babel-plugin-middleware-decorator/index.js
@@ -71,15 +71,71 @@ const addSuperToConstructor = (path, types) => {
     constructor.get('body').unshiftContainer('body', superCall);
 };
 
+/**
+ * Attempt to read package.json located by p
+ * @param {string} packageJsonPath 
+ */
+const getPackageJson = (packagePath) => {
+    const packageJsonPath = path.join(packagePath, 'package.json');
+
+    try {
+        return require(packageJsonPath);
+    } catch (err) {
+        return {}
+    }
+}
+
+/**
+ * Memoization strategy is valid only for functions with 1 argument
+ * This strategy works better with 1-argument functions
+ * 
+ * @param {function} cb 
+ */
+const memoizeBySingleArgument = (cb) => {
+    const memoizedValues = {};
+
+    return (arg) => {
+        // Handle new value
+        if (!memoizedValues[arg]) {
+            const result = cb(arg);
+            memoizedValues[arg] = result;
+        }
+        
+        return memoizedValues[arg];
+    };
+}
+
+const isScandipwaPackageFile = memoizeBySingleArgument((filePath) => {
+    // Potentially, only the files inside of the src/ directory need to be transpiled
+    const src = filePath.lastIndexOf('/src/');
+
+    const packagePath = filePath.slice(0, src);
+    const packageJson = getPackageJson(packagePath);
+
+    // If package.json has `scandipwa` configurations => is a scandipwa package
+    if (packageJson.scandipwa) {
+        return true;
+    }
+
+    return false;
+});
+
 const isMustProcessNamespace = (state) => {
     const { filename } = state.file.opts;
 
+    // Handle enabled extensions: 'src/', 'public/'
     for (let i = 0; i < allowedPaths.length; i++) {
         const allowedPath = allowedPaths[i];
 
         if (filename.includes(allowedPath)) {
             return true;
         }
+    }
+
+    // Handle packages which don't need to be explicitly enabled
+    // E.g. @scandipwa/form
+    if (isScandipwaPackageFile(filename)) {
+        return true;
     }
 
     return false;


### PR DESCRIPTION
### Overview

Function `Extensibility` and the Babel plugin which provide the plugin system's functionality to the application contain flaws, which in some cases break the application. This PR fixes these issues.

The cache identity for generated classes is now prevented from being inherited.
It is now double-checked whether the package is meant to be transpiled by the babel plugin. To do that, the package's `package.json` is used.