### PR TITLE
I18n "non extractable" error improvements

### DIFF
--- a/build-packages/webpack-i18n-runtime/build-config/webpack-i18n-tracker/after-emit-logs/non-extractable-translation.js
+++ b/build-packages/webpack-i18n-runtime/build-config/webpack-i18n-tracker/after-emit-logs/non-extractable-translation.js
@@ -9,7 +9,7 @@ module.exports = (nonExtractableList) => {
     );
 
     return {
-        type: 'error',
+        type: 'warn',
         args: [
             'Non-extractable translations found in your application!',
             'Consider refactoring them so that they are translatable.',

--- a/build-packages/webpack-i18n-runtime/build-config/webpack-i18n-tracker/localization-manager/index.js
+++ b/build-packages/webpack-i18n-runtime/build-config/webpack-i18n-tracker/localization-manager/index.js
@@ -171,6 +171,10 @@ class LocalizationManager {
     }
 
     handleNonExtractableCases() {
+        if (!this.nonExtractableCases.length) {
+            return;
+        }
+
         afterEmitLogger.logMessage(nonExtractableTranslationMessage(this.nonExtractableCases));
     }
 


### PR DESCRIPTION
### Overview

This PR contains some minor fixes for the cases when non extractable values are passed to the `__()` function in the application.

1. The error message is no more constantly shown
2. The error message is no more an error message - it is a warning now