### PR TITLE
Switch proxy to 40kskudemo.scandipwa.com

### DIFF
--- a/build-packages/csa-generator-theme/index.js
+++ b/build-packages/csa-generator-theme/index.js
@@ -7,7 +7,7 @@ const logger = require('@scandipwa/scandipwa-dev-utils/logger');
 const { getComposerDeps } = require('@scandipwa/scandipwa-dev-utils/composer');
 const writeJson = require('@scandipwa/scandipwa-dev-utils/write-json');
 
-const DEFAULT_PROXY = 'https://scandipwapmrev.indvp.com';
+const DEFAULT_PROXY = 'https://40kskudemo.scandipwa.com/';
 
 const ensureLatestComposer = (pathname) => {
     const composerDeps = getComposerDeps(pathname);


### PR DESCRIPTION
This PR contains changes that will change default proxy to the demo store instead of indvp because invdp is used only for internal testing and not consistent over time.