### PR TITLE
Fixed windows path resolve issue

### DIFF
--- a/build-packages/scandipwa-extensibility/build-config/webpack-extension-import-helper-loader/index.js
+++ b/build-packages/scandipwa-extensibility/build-config/webpack-extension-import-helper-loader/index.js
@@ -6,7 +6,11 @@ const path = require('path');
  * But it will occur before ReactDOM.render()
  */
 module.exports = function injectImports(source) {
-    const injectablePath = path.resolve(__dirname, '..', '..', 'runtime-helpers');
+    const injectablePath = path
+        .resolve(__dirname, '..', '..', 'runtime-helpers')
+        .split(path.sep)
+        .join(path.posix.sep);
+
     const injectableCode = `import '${injectablePath}';\n`;
 
     const importMatcher = /^import .+$/gm;

--- a/build-packages/scandipwa-extensibility/build-config/webpack-extension-import-loader/index.js
+++ b/build-packages/scandipwa-extensibility/build-config/webpack-extension-import-loader/index.js
@@ -48,7 +48,10 @@ const getExtensionImports = (pathname) => {
         return [];
     }
 
-    return findPluginFiles(pathname).map((pluginFile) => `require('${pluginFile}').default`);
+    return findPluginFiles(pathname).map((pluginFile) => {
+        const pluginFilePath = pluginFile.split(path.sep).join(path.posix.sep);
+        return `require('${pluginFilePath}').default`;
+    });
 };
 
 module.exports = function injectImports(source) {

--- a/build-packages/scandipwa-scripts/lib/alias.js
+++ b/build-packages/scandipwa-scripts/lib/alias.js
@@ -62,9 +62,11 @@ const preferenceAliases = extensions.reduce((acc, extension) => {
         return acc;
     }
 
+    const posixPackagePath = packagePath.split(path.sep).join(path.posix.sep);
+
     return {
         ...acc,
-        [`${preference}/*`]: [path.relative(process.cwd(), packagePath)]
+        [`${preference}/*`]: [path.relative(process.cwd(), posixPackagePath)]
     };
 }, {});
 
@@ -78,9 +80,10 @@ const { parentThemeAliases } = Object.entries(aliasMap).reduceRight(
     (acc, [, aliasPathMap]) => {
         Object.entries(aliasPathMap).forEach(
             ([alias, pathname], i) => {
+                const posixPathname = pathname.split(path.sep).join(path.posix.sep);
                 acc.aliasStack[i].push(
                     // it is required to be relative, otherwise it does not work
-                    `${path.relative(process.cwd(), pathname)}/*`
+                    `${path.relative(process.cwd(), posixPathname)}/*`
                 );
 
                 acc.parentThemeAliases[`${ alias }/*`] = Array.from(acc.aliasStack[i]);
@@ -98,7 +101,7 @@ const { parentThemeAliases } = Object.entries(aliasMap).reduceRight(
 // TODO: generate jsconfig.js for VSCode suggestions
 const jsConfig = {
     compilerOptions: {
-        baseUrl: `.${path.sep}`,
+        baseUrl: `.${path.posix.sep}`,
         jsx: 'react',
         paths: {
             ...parentThemeAliases,

--- a/build-packages/webpack-i18n-plugin/index.js
+++ b/build-packages/webpack-i18n-plugin/index.js
@@ -23,7 +23,11 @@ const addParsedVariableToModule = (parser, name) => {
         return false;
     }
 
-    const pathToTranslationFunction = path.join(__dirname, 'lib/translation-function.js');
+    const pathToTranslationFunction = path
+        .join(__dirname, 'lib/translation-function.js')
+        .split(path.pos)
+        .join(path.posix.pos);
+
     const expression = `require(${ JSON.stringify(pathToTranslationFunction) })`;
     const deps = [];
 

--- a/build-packages/webpack-i18n-runtime/build-config/webpack-i18n-import-loader/index.js
+++ b/build-packages/webpack-i18n-runtime/build-config/webpack-i18n-import-loader/index.js
@@ -28,8 +28,9 @@ function getFilePathsForLocale(locale) {
     );
 }
 
-function generateImportDeclaration(path, chunkName) {
-    return `import(/* webpackMode: "lazy", webpackChunkName: "${chunkName}" */ '${path}')`;
+function generateImportDeclaration(pathname, chunkName) {
+    const posixPathname = pathname.split(path.sep).join(path.posix.sep);
+    return `import(/* webpackMode: "lazy", webpackChunkName: "${chunkName}" */ '${posixPathname}')`;
 }
 
 function generateLocaleMapContents(localePathMap, defaultLocale) {


### PR DESCRIPTION
Fixes #11

Unlike in *nix systems, windows is using a backslash as a directory separator.
But windows can handle paths with the normal slash also.
And the backslash is used for the special characters like `\n`, `\r`, etc.

When we use path functions for joining, resolving modules, we have combined path strings with the `/` and `\` slashes. And this is ok. But when we output this path strings, the backslash is converted to a special char, if it wasn't escaped.

Some of the code is dynamicaly combined with the unescaped slashes, so the issue happens. For example:
```
findPluginFiles(pathname).map((pluginFile) => `require('${pluginFile}').default`);
```

I was trying to search such code and convert backslashes to the normal ones.
I didn't touch most of the code, only the parts, where paths are output as strings.
I've tested the app run, build and override actions. Everything looks fine.