### PR TITLE
Broken store imports fix

### DIFF
--- a/build-packages/scandipwa-extensibility/build-config/webpack-extension-import-helper-loader/index.js
+++ b/build-packages/scandipwa-extensibility/build-config/webpack-extension-import-helper-loader/index.js
@@ -1,26 +1,43 @@
 const path = require('path');
 
+const getSlicePoint = (source) => {
+    // Attempt to match by hook
+    const hookMatcher = '/** ENTRY__HOOK */';
+    const hookPosition = source.indexOf(hookMatcher);
+
+    if (hookPosition) {
+        return hookPosition;
+    }
+
+    // Attempt to match by imports
+    const importMatcher = /^import .+$/gm;
+    const imports = source.match(importMatcher);
+
+    // If no imports => make one
+    if (!imports || !imports.length) {
+        return 0;
+    }
+
+    // There are imports => take the first one
+    const firstImport = imports[0];
+    const firstImportPosition = source.indexOf(firstImport);
+
+    return firstImportPosition;
+};
+
 /**
  * This will import the neighboring runtime-helpers into the application
  * The import will be the last import in the application's entry point
  * But it will occur before ReactDOM.render()
  */
 module.exports = function injectImports(source) {
-    const injectablePath = path
-        .resolve(__dirname, '..', '..', 'runtime-helpers')
-        .split(path.sep)
-        .join(path.posix.sep);
-
+    const injectablePath = path.resolve(__dirname, '..', '..', 'runtime-helpers');
     const injectableCode = `import '${injectablePath}';\n`;
 
-    const importMatcher = /^import .+$/gm;
-    const imports = source.match(importMatcher);
+    const slicePoint = getSlicePoint(source);
 
-    const firstImport = imports[0];
-    const firstImportPosition = source.indexOf(firstImport);
-
-    const codeBeforeInjectable = source.slice(0, firstImportPosition);
-    const codeAfterInjectable = source.slice(firstImportPosition);
+    const codeBeforeInjectable = source.slice(0, slicePoint);
+    const codeAfterInjectable = source.slice(slicePoint);
 
     const injectedCode = [
         codeBeforeInjectable,


### PR DESCRIPTION
### Overview

This PR provide an opportunity to control import sequence in the application's entry point.

Before, the extensions' entry point was the first import the application.
It caused some issues, e.g. some circular dependencies were not able to be resolved if go through the plugins' dependency tree, whilst being able to be resolved without plugins. 

Magic comment `/** ENTRY_HOOK */` is now replaced by extensions' initialization import.

This PR resolves https://github.com/scandipwa/scandipwa/issues/2018