### PR TITLE
Change the way to resolve the path of webpack-i18n-import-loader

### DIFF
--- a/build-packages/webpack-i18n-runtime/build-config/config.plugin.js
+++ b/build-packages/webpack-i18n-runtime/build-config/config.plugin.js
@@ -20,7 +20,7 @@ const addResolveLoader = (config) => {
 const addImportInjector = (config) => {
     config.module.rules.push({
         test: require.resolve(path.join(__dirname, '../src/util/localeMap.js')),
-        loader: 'webpack-i18n-import-loader'
+        loader: require.resolve('./webpack-i18n-import-loader')
     });
 };
 


### PR DESCRIPTION
This fix is required in case to make a Storybook for ScandiPWA working.

When loading Storybook -- it can't find a correct path for webpack-i18n-import-loader module. So that I'm getting the next error message:

![image](https://user-images.githubusercontent.com/14853681/124564370-a8befd80-de49-11eb-9037-bf42e3371ac4.png)

With require.resolve() function the path is defined manually and I'm receiving the right configuration.