### PR TITLE
Added undefined prop to the service-worker package

### DIFF
--- a/build-packages/service-worker/build-config/workbox-dev.js
+++ b/build-packages/service-worker/build-config/workbox-dev.js
@@ -13,6 +13,10 @@ module.exports = {
         overrideCracoConfig: ({
             cracoConfig
         }) => {
+            if (!cracoConfig.paths) {
+                Object.assign(cracoConfig, { paths: {} });
+            }
+
             // Modify the default path to ServiceWorker (in case CRA changes something)
             cracoConfig.paths.swSrc = swSrc;
             return cracoConfig;

--- a/build-packages/service-worker/build-config/workbox-dev.js
+++ b/build-packages/service-worker/build-config/workbox-dev.js
@@ -14,7 +14,7 @@ module.exports = {
             cracoConfig
         }) => {
             if (!cracoConfig.paths) {
-                Object.assign(cracoConfig, { paths: {} });
+                cracoConfig.paths = {};
             }
 
             // Modify the default path to ServiceWorker (in case CRA changes something)


### PR DESCRIPTION
When i enable `@scandipwa/bundle-analyzer` package, i get this error on app start.
```
(node:689099) UnhandledPromiseRejectionWarning: TypeError: Cannot set property 'swSrc' of undefined
```
Fixed this by adding default value for the `paths` property.