### PR TITLE
this fixes linting in the repo by husky for generator packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
             "build-packages/craco/**",
             "runtime-packages/scandipwa/**",
             "runtime-packages/cma/**",
+            "build-packages/csa-generator-*/template/**",
             "build-packages/eslint-plugin-scandipwa-guidelines/**",
             "build-packages/scandipwa-development-toolkit-vscode/**",
             "build-packages/scandipwa-development-toolkit-core/**",


### PR DESCRIPTION
Currently, when trying to commit anything in this repo, it will break because generator packages have a template folder in them and there is template package.json with an invalid name which causes eslint to die.