### PR TITLE
Add homepage and repository fields in package json (original #44)

### DIFF
--- a/build-packages/scandipwa-scripts/package.json
+++ b/build-packages/scandipwa-scripts/package.json
@@ -2,6 +2,8 @@
     "name": "@scandipwa/scandipwa-scripts",
     "description": "Scripts and configuration used by CSA.",
     "version": "2.4.6",
+    "homepage": "https://docs.create-scandipwa-app.com/",
+    "repository": "github:scandipwa/create-scandipwa-app",
     "bin": {
         "scandipwa-scripts": "./bin/scandipwa-scripts.js"
     },


### PR DESCRIPTION
`@scandipwa/scandipwa-scripts` doesn't have `homepage` field in `package.json`. Because of that, we're missing links from NPM to this repo, as well as links in our editors.
![Screenshot_20210722_175101](https://user-images.githubusercontent.com/18352350/126659841-c8dbf6de-16cb-488f-adca-37da717bb8a2.png)

![Screenshot_20210722_175037](https://user-images.githubusercontent.com/18352350/126659780-57a85eba-673e-4bd7-94fe-cf662b06c7bd.png)


`@scandipwa/magento-scripts` does have them, and this is how it looks:
![Screenshot_20210722_175130](https://user-images.githubusercontent.com/18352350/126659932-3f4ba7fe-7a8e-4dcb-b64d-92074c0323db.png)

VSCode also shows our URL in package preview in `package.json`.
![Screenshot_20210325_170215](https://user-images.githubusercontent.com/18352350/112494665-e95ba500-8d8b-11eb-8a70-9184740bb74a.png)
