### PR TITLE
CSA NPM Installation Fix

### DIFF
--- a/build-packages/csa-generator-theme/index.js
+++ b/build-packages/csa-generator-theme/index.js
@@ -123,6 +123,7 @@ const run = async (options) => {
     let scandipwaScriptsVersion = '0.0.0';
     let mosaicVersion = '0.0.0';
     let eslintConfigVersion = '0.0.0';
+    let mosaicCracoVersion = '0.0.0';
 
     try {
         scandipwaVersion = await getLatestVersion('@scandipwa/scandipwa');
@@ -156,11 +157,20 @@ const run = async (options) => {
         );
     }
 
+    try {
+        mosaicCracoVersion = await getLatestVersion('@tilework/mosaic-craco');
+    } catch (e) {
+        logger.warn(
+            `Unable to determine the latest version of package ${logger.style.misc('@tilework/mosaic-craco')}`
+        );
+    }
+
     const templateOptions = {
         scandipwaVersion,
         scandipwaScriptsVersion,
         name,
         mosaicVersion,
+        mosaicCracoVersion,
         proxy: DEFAULT_PROXY,
         eslintConfigVersion
     };

--- a/build-packages/csa-generator-theme/template/package.json
+++ b/build-packages/csa-generator-theme/template/package.json
@@ -6,7 +6,8 @@
         "@scandipwa/scandipwa": "<%= scandipwaVersion %>",
         "@scandipwa/scandipwa-scripts": "<%= scandipwaScriptsVersion %>",
         "@scandipwa/eslint-config": "<%= eslintConfigVersion %>",
-        "@tilework/mosaic": "<%= mosaicVersion %>"
+        "@tilework/mosaic": "<%= mosaicVersion %>",
+        "@tilework/mosaic-craco": "<%= mosaicCracoVersion %>"
     },
     "scandipwa": {
         "type": "theme",


### PR DESCRIPTION
Fixes scandipwa/scandipwa#3145

Added `@tilework/mosaic-craco` to CSA generator in order to fix issue when it's missing on install with npm v6.